### PR TITLE
Add published fork to fix function name and snapshot tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+coverage
 node_modules

--- a/__tests__/__snapshots__/app.test.js.snap
+++ b/__tests__/__snapshots__/app.test.js.snap
@@ -1,0 +1,9 @@
+exports[`app should render 1`] = `
+<div>
+  <Header />
+  <main>
+    I am content
+  </main>
+  <Footer />
+</div>
+`;

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1,0 +1,12 @@
+const App = require('../app')
+const React = require('react')
+const toJSON = require('enzyme-to-json').default
+const shallow = require('enzyme').shallow
+
+describe('app', () => {
+  it('should render', () => {
+    const tree = toJSON(shallow(<App />))
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/app.js
+++ b/app.js
@@ -1,0 +1,19 @@
+const React = require('react')
+
+const Header = () => (
+  <header>I am header</header>
+)
+
+const Footer = () => (
+  <footer>I am footer</footer>
+)
+
+const App = () => (
+  <div>
+    <Header />
+    <main>I am content</main>
+    <Footer />
+  </div>
+)
+
+module.exports = App

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "index.js",
   "scripts": {
     "test:node": "node test.js",
-    "test:babel-node": "babel-node --plugins istanbul test.js"
+    "test:babel-node": "BABEL_DISABLE_CACHE=1 babel-node --plugins istanbul test.js",
+    "test:fork:babel-node": "BABEL_DISABLE_CACHE=1 babel-node --plugins @wyze/babel-plugin-istanbul test.js",
+    "test:snapshot": "jest __tests__/app.test.js",
+    "test:snapshot:coverage": "NODE_ENV=test npm run test:snapshot -- --coverage --no-cache",
+    "test:fork:snapshot:coverage": "NODE_ENV=test-fork npm run test:snapshot -- --coverage --no-cache"
   },
   "repository": {
     "type": "git",
@@ -19,7 +23,38 @@
   },
   "homepage": "https://github.com/kentcdodds/issue-babel-plugin-istanbul-fn-name#readme",
   "devDependencies": {
+    "@wyze/babel-plugin-istanbul": "^3.0.2",
     "babel-cli": "^6.16.0",
-    "babel-plugin-istanbul": "^2.0.1"
+    "babel-jest": "^18.0.0",
+    "babel-plugin-istanbul": "^2.0.1",
+    "babel-preset-react": "^6.16.0",
+    "enzyme": "^2.6.0",
+    "enzyme-to-json": "^1.4.5",
+    "jest": "^18.0.0",
+    "react-addons-test-utils": "^15.4.1"
+  },
+  "dependencies": {
+    "react": "^15.4.1",
+    "react-dom": "^15.4.1"
+  },
+  "babel": {
+    "env": {
+      "test": {
+        "plugins": [
+          "istanbul"
+        ],
+        "presets": [
+          "react"
+        ]
+      },
+      "test-fork": {
+        "plugins": [
+          "@wyze/babel-plugin-istanbul"
+        ],
+        "presets": [
+          "react"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
Hey Kent!

I came across your issue and decided it was an interesting one to solve. I too am using snapshot testing and ran into the displayName issue for components. I have a semi robust module, [`babel-plugin-transform-react-stateless-component-name`](https://github.com/wyze/https://github.com/wyze/babel-plugin-transform-react-stateless-component-name) that I currently use to get around the current displayName issues in `babel-plugin-istanbul`.

Anyways, I commented on your issue you reported where you linked to this repo. I am sending a PR that includes the 2 fixes needed, one to `istanbul-lib-instrument` and the other to `babel-plugin-istanbul`. I published scoped modules under my name which are included in this PR here. Hopefully we can get those merged soon!

---

# Scripts

I've added a few more scripts to the mix here as well as an example of a snapshot test passing. If you run your existing script `npm run test:babel-node`, you see it fails. But, if you now run `npm run test:fork:babel-node` you will see it uses my forked plugin and tests pass!

## Snapshots

With snapshot you can see if you run `npm run test:snapshot` that it passes since there is no coverage being applied. Now, if you run `npm run test:snapshot:coverage` it will run `jest -- --coverage` with `babel-plugin-istanbul` and fail. The snapshot now contains `<Component />` instead of the proper displayNames.

Next if you run `npm run test:fork:snapshot:coverage` it will again use the forked plugin and passes as the correct displayNames are applied.

---

No action needed on this PR, I just wanted to show you that progress has been made and hopefully we can get the PRs to the respective libraries merged soon!